### PR TITLE
[FWB-79] Sanitize middleware to strip non-ascii and dangerous HTML

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,0 +1,23 @@
+const asciiFolder = require('fold-to-ascii');
+const xss = require('xss');
+
+const xssOptions = {
+	stripIgnoreTag: true, // strip out tags not in whitelist instead of escaping them
+};
+
+const sanitize = (req, res, next) => {
+	let bodyString = JSON.stringify(req.body);
+
+	// Strip untrusted HTML from the body of incoming requests to prevent XSS attacks
+	bodyString = xss(bodyString, xssOptions);
+
+	// Normalize known non-ascii characters to ascii and strip unknown non-ascii characters
+	bodyString = asciiFolder.foldReplacing(bodyString);
+
+	req.body = JSON.parse(bodyString);
+	next();
+};
+
+module.exports = {
+	sanitize: sanitize,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1173,9 +1173,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1241,6 +1239,11 @@
           "dev": true
         }
       }
+    },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "cssom": {
       "version": "0.3.8",
@@ -2062,6 +2065,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "fold-to-ascii": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fold-to-ascii/-/fold-to-ascii-5.0.0.tgz",
+      "integrity": "sha512-HjtRWXC9aVit47DOEqvorgaQDiIyeX+frV3tM22RlllposIxnPXRM/vYoE6y6pwW57RdgahSe32Cu0vf4/UX1Q=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -6274,6 +6282,15 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xss": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.6.tgz",
+      "integrity": "sha512-6Q9TPBeNyoTRxgZFk5Ggaepk/4vUOYdOsIUYvLehcsIZTFjaavbVnsuAkLA5lIFuug5hw8zxcB9tm01gsjph2A==",
+      "requires": {
+        "commander": "^2.9.0",
+        "cssfilter": "0.0.10"
+      }
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "bunyan": "1.8.12",
     "dotenv": "6.1.0",
     "dotenv-parse-variables": "0.2.2",
-    "joi": "13.7.0"
+    "fold-to-ascii": "^5.0.0",
+    "joi": "13.7.0",
+    "xss": "^1.0.6"
   },
   "peerDependencies": {
     "boom": "7.x",

--- a/tests/middleware/index.test.js
+++ b/tests/middleware/index.test.js
@@ -1,0 +1,80 @@
+const middleware = require('../../middleware/index');
+
+describe('middleware', () => {
+	describe('middleware.sanitize', () => {
+		test('should strip non-whitelisted HTML tags from request body', () => {
+			const string = '<script>This could be dangerous!</script>';
+			const sanitizedString = 'This could be dangerous!';
+
+			const request = {
+				body: {
+					string,
+					something: {
+						string,
+					},
+				},
+			};
+
+			middleware.sanitize(request, {}, () => {});
+
+			expect(request.body.string).toEqual(sanitizedString);
+			expect(request.body.something.string).toEqual(sanitizedString);
+		});
+
+		test('should retain whitelisted HTML tags in request body', () => {
+			const string = 'This is <strong>totally</strong> fine.';
+
+			const request = {
+				body: {
+					string,
+					something: {
+						string,
+					},
+				},
+			};
+
+			middleware.sanitize(request, {}, () => {});
+
+			expect(request.body.string).toEqual(string);
+			expect(request.body.something.string).toEqual(string);
+		});
+
+		test('should replace known non-ascii characters in request body with their ascii equivalents', () => {
+			const string = 'here\'s the problem ֆāĕĢ the rest is fine';
+			const sanitizedString = 'here\'s the problem aeG the rest is fine';
+
+			const request = {
+				body: {
+					string,
+					something: {
+						string,
+					},
+				},
+			};
+
+			middleware.sanitize(request, {}, () => {});
+
+			expect(request.body.string).toEqual(sanitizedString);
+			expect(request.body.something.string).toEqual(sanitizedString);
+		});
+
+		test('should strip out unknown non-ascii characters in request body', () => {
+			const string = 'ֆƱupsilon ɸphi';
+			const sanitizedString = 'upsilon phi';
+
+			const request = {
+				body: {
+					string,
+					something: {
+						string,
+					},
+				},
+			};
+
+			middleware.sanitize(request, {}, () => {});
+
+			expect(request.body.string).toEqual(sanitizedString);
+			expect(request.body.something.string).toEqual(sanitizedString);
+		});
+	});
+});


### PR DESCRIPTION
https://greenchef.atlassian.net/browse/FWB-79

For use in both shipping-platform and core API when available.

Core API (script to strip non-ascii from some user fields): https://github.com/greenchef/greenchef/pull/5139