### PR TITLE
Don't turn TypeError into FailedDependency.

### DIFF
--- a/middleware/http-error-handler.middleware.js
+++ b/middleware/http-error-handler.middleware.js
@@ -16,8 +16,6 @@ const httpErrorHandler = (err, _req, res, _next) => { // eslint-disable-line no-
 			responseErr = Boom.badRequest(responseErr.message);
 		} else if (responseErr.name === 'UnauthorizedError') {
 			responseErr = Boom.unauthorized(responseErr.message);
-		} else if (responseErr.name === 'TypeError') {
-			responseErr = Boom.failedDependency(responseErr.message);
 		} else {
 			responseErr = Boom.boomify(new Error(responseErr), { statusCode: responseErr.status });
 		}


### PR DESCRIPTION
TypeErrors are caused by coding mistakes and should be ServerErrors.
That way they will be logged

This is a tiny change but I think an important one. Without it, errors could be missed and not logged.