### PR TITLE
[WLA-137] update logger to follow awslogs-multiline-pattern

### DIFF
--- a/initializers/logger.js
+++ b/initializers/logger.js
@@ -1,5 +1,6 @@
 const bunyan = require('bunyan');
 const stackTrace = require('stacktrace-js');
+const moment = require('moment');
 
 const DEFAULT_OPTIONS = {
 	name: process.env.LOGGER_NAME,
@@ -49,6 +50,8 @@ const createGcLogger = logger => ({
 				group = group || `${file}:${line}:${col}`;
 				subGroup = subGroup || func;
 			}
+
+			message = `[${moment().format()}][${level.toUpperCase()}] ${message}`;
 
 			return logger[level]({
 				err,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "latinize": "^0.4.1",
     "lodash": "^4.17.15",
     "merge-deep": "^3.0.2",
+    "moment": "^2.29.1",
     "sqs-consumer": "5.4.0",
     "stacktrace-js": "^2.0.2"
   },


### PR DESCRIPTION
I need to figure out how to test this but currently the logger doesn't follow "awslogs-multiline-pattern": "^\\[" but I believe this will resolve it