### PR TITLE
[FWK-614] cleans up bull job listeners and reworks their logging

### DIFF
--- a/initializers/logger.js
+++ b/initializers/logger.js
@@ -43,7 +43,8 @@ const createGcLogger = logger => ({
 				} else if (err.response && err.response.body) {
 					resData = `${err.response.statusMessage} ${err.response.body}`
 				}
-				message = `${data.supplementalMessage} ${resData}`;
+				data.responseData = resData;
+				message = `${data.supplementalMessage}`;
 			} else {
 				throw Error("First argument to log methods must be an Error or 'string' message");
 			}

--- a/initializers/logger.js
+++ b/initializers/logger.js
@@ -96,9 +96,9 @@ const createLogger = options => {
 	const resolvedOptions = {
 		...DEFAULT_OPTIONS,
 		...options
-	  };
+	};
 
-	if(!resolvedOptions.name) {
+	if (!resolvedOptions.name) {
 		throw Error('Logger name not provided for logger initializer.');
 	}
 

--- a/jobs/base.bull.job.js
+++ b/jobs/base.bull.job.js
@@ -87,7 +87,8 @@ class BaseJob {
 			const doneWrapper = (err) => {
 				apmTransaction.result = err ? 'error' : 'success'
 				apmTransaction.end();
-				this.logger.info(`Job completed in ${Date.now() - startTime} milliseconds`)
+				const executionTime = Date.now() - startTime
+				this.logger.debug(`${this.constructor.name} completed in ${executionTime} milliseconds`, { executionTime, attempt: job.attemptsMade, job: this.constructor.name })
 				done(err);
 			}
 

--- a/jobs/base.bull.job.js
+++ b/jobs/base.bull.job.js
@@ -88,7 +88,7 @@ class BaseJob {
 				apmTransaction.result = err ? 'error' : 'success'
 				apmTransaction.end();
 				const executionTime = Date.now() - startTime
-				this.logger.debug(`${this.constructor.name} completed in ${executionTime} milliseconds`, { executionTime, attempt: job.attemptsMade, job: this.constructor.name })
+				this.logger.debug(`${this.constructor.name} completed in ${executionTime} milliseconds`, { executionTime, attempt: job.attemptsMade, startTime })
 				done(err);
 			}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gc-platform-utils",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "A collection of various utilities to be used across the Green Chef ecosystem.",
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Ticket: https://greenchef.atlassian.net/browse/FWK-614 
goes with: https://github.com/greenchef/shipping-platform/pull/389, https://github.com/greenchef/auth-platform/pull/76

Removed the global event listeners as they were just duplicating the queue listeners. Decided to keep queue listeners over global as they  have access to more data around the job, global listeners only get access to the job id.